### PR TITLE
SE-1673:- Adds logic to prevent IE scrollbar drag bug.

### DIFF
--- a/vaadin-combo-box-behavior.html
+++ b/vaadin-combo-box-behavior.html
@@ -179,7 +179,7 @@
     },
 
     _onBlur: function() {
-      if (!this._closeOnBlurIsPrevented) {
+      if (!this._closeOnBlurIsPrevented && document.activeElement !== this.$.overlay.$.scroller) {
         this.close();
       }
     },


### PR DESCRIPTION
• vaadin-combo-box was forked to introduce this fix.
• vaadin-combo-box could not be updated to 2.0.0 where the fix is made because the updating across multiple dependencies would be too expensive.
• the fix for this bug was taken from commit 9f5897d - Fix overlay scrolling via the scrollbar in IE.
• only the single line from vaadin-combo-box-behavior.html was necessary.
• branch 1.x was started from tag 1.3.3 (the original 1.x branch before we forked had 18 additional commits that we didn't care about)